### PR TITLE
standardize policy template button icons

### DIFF
--- a/templates/policy_template_list_base.html
+++ b/templates/policy_template_list_base.html
@@ -67,7 +67,7 @@
                                                 <div style="position: relative">
                                                     <span class="icon-input-btn">
                                                         <button value="Choose {{ mixed_policy_template.body|safe }} Template" class="btn btn-primary btn-md pull-right custom-btn" type="submit" name="commit" >
-                                                            <i class="fa fa-file-powerpoint-o" style="font-size: 1.3em; color: white;"></i>
+                                                            <i class="fa fa-file-word-o" style="font-size: 1.3em; color: white;"></i>
                                                             {{ button_text }} Template
                                                         </button>
                                                     </span>
@@ -89,7 +89,7 @@
                                                     <span class="icon-input-btn">
                                                         <button value="Choose {{ fully_encouraging_policy_template.name|safe }} Template" class="btn btn-primary btn-md pull-right custom-btn" type="submit" name="commit">
                                                             <span class="fa-layers fa-fw">
-                                                                <i class="fa fa-file-o" style="font-size: 1.3em; color: white;"></i>
+                                                                <i class="fa fa-file-word-o" style="font-size: 1.3em; color: white;"></i>
                                                                 <i class="fa fa-times" style="position: absolute; font-size: .75em; color: white; margin-left: -1.6em; margin-top: .68em;"></i>
                                                             </span>
                                                             {{ button_text }} Template


### PR DESCRIPTION
# Overview

The purpose of this PR is to standardize the icons on the *Choose Template* buttons in the AI policy templates and successfully deploy to dev. [Jira ATGU-4991](https://at-harvard.atlassian.net/jira/software/c/projects/ATGU/boards/36?selectedIssue=ATGU-4991)

# Changes

- Icons on the *Choose Template* buttons of policy templates updated to word-doc icons via `templates/policy_template_list_base.html`

# Notes

- Related to https://github.com/Harvard-ATG/academic_integrity_tool_v2/issues/32

Image Below: AI Policy Tool Dev on my demo Canvas Site [[Link](https://canvas.harvard.edu/courses/158625/external_tools/112559)].  Buttons are consistent.

<img src="https://github.com/user-attachments/assets/fac961f8-785e-4f7b-aa26-e8776a50ca05" width="400">