### PR TITLE
Fix 'Choose Template' Button Icon Overlap and Improvon Icon UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ secure.py
 gunicorn.py
 # Where static files are collected
 http_static
+.env

--- a/templates/policy_template_list_base.html
+++ b/templates/policy_template_list_base.html
@@ -90,7 +90,6 @@
                                                         <button value="Choose {{ fully_encouraging_policy_template.name|safe }} Template" class="btn btn-primary btn-md pull-right custom-btn" type="submit" name="commit">
                                                             <span class="fa-layers fa-fw">
                                                                 <i class="fa fa-file-word-o" style="font-size: 1.3em; color: white;"></i>
-                                                                <i class="fa fa-times" style="position: absolute; font-size: .75em; color: white; margin-left: -1.6em; margin-top: .68em;"></i>
                                                             </span>
                                                             {{ button_text }} Template
                                                         </button>

--- a/templates/policy_template_list_base.html
+++ b/templates/policy_template_list_base.html
@@ -45,7 +45,7 @@
                                                 <div style="position: relative">
                                                     <span class="icon-input-btn">
                                                         <button value="Choose {{ maximally_restrictive_policy_template.name|safe }} Template" class="btn btn-primary btn-md pull-right custom-btn" type="submit" name="commit">
-                                                            <i class="fa fa-file-word-o" style="font-size: 1.3em; color: white;"></i>
+                                                            <i class="fa-light fa-file-lines" style="font-size: 1.3em; color: white;"></i>
                                                             {{ button_text }} Template
                                                         </button>
                                                     </span>
@@ -67,7 +67,7 @@
                                                 <div style="position: relative">
                                                     <span class="icon-input-btn">
                                                         <button value="Choose {{ mixed_policy_template.body|safe }} Template" class="btn btn-primary btn-md pull-right custom-btn" type="submit" name="commit" >
-                                                            <i class="fa fa-file-word-o" style="font-size: 1.3em; color: white;"></i>
+                                                            <i class="fa-light fa-file-lines" style="font-size: 1.3em; color: white;"></i>
                                                             {{ button_text }} Template
                                                         </button>
                                                     </span>
@@ -89,7 +89,7 @@
                                                     <span class="icon-input-btn">
                                                         <button value="Choose {{ fully_encouraging_policy_template.name|safe }} Template" class="btn btn-primary btn-md pull-right custom-btn" type="submit" name="commit">
                                                             <span class="fa-layers fa-fw">
-                                                                <i class="fa fa-file-word-o" style="font-size: 1.3em; color: white;"></i>
+                                                                <i class="fa-light fa-file-lines" style="font-size: 1.3em; color: white;"></i>
                                                             </span>
                                                             {{ button_text }} Template
                                                         </button>


### PR DESCRIPTION
# Overview

This PR fixes overlapping icons on the 'Choose Template' button and replaces the word doc icon with a more appropriate file lines icon for better user experience.  Additionally, it updates `.gitignore` to ignore`.env` files used in local development and adds a `.env.example` for developers to quickly configure the `.env` file.

# Changes

- Remove extraneous times icon
- Replaces word doc icon `fa fa-file-word-o` with file lines icon `fa-light fa-file-lines`
- Adds `.env` to `.gitignore `file
- Adds `.env.example` file

# Notes

## Change Icon
The user experience after clicking the 'Choose Template' button is a text field where an AI policy statement is pre-populated in a text field, but the text in the field can be modified and saved. Given this user interface, the word doc icon is not the most appropriate as it typically denotes uploading / downloading a word document, which is not the case here.  The file lines icon better aligns with the experience users will have once they click the the 'Choose Template' button, a field with text in it.

## .env
The docker-compose locally looks for a .env file for the NGROK url where the application can be hosted and tested locally. Since developers will be asked to create a .env file, adding it to .gitignore prevents the .env file from getting picked up. Adding the .env.example gives developers an example of what their .env file should include.

# References
- Add before and after images here for the AI policy template GUID