### PR TITLE
add developer experience enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,10 @@ ALLOWED_HOSTS=127.0.0.1,localhost,.ngrok-free.app
 X_FRAME_OPTIONS=ALLOW-FROM https://harvard.beta.instructure.com
 
 ### Session / cookie management
-# Help keep session cookie settings
+# These default to True and None in secure.py when not set — no need to uncomment.
+# Both values work on localhost (browsers treat it as a secure context even over HTTP)
+# and via ngrok (actual HTTPS). SameSite=None is required for Canvas LTI iframe launches
+# (cross-site POST), and Secure=True is required by browsers when SameSite=None.
 # DJANGO_SESSION_COOKIE_SECURE=True
 # DJANGO_SESSION_COOKIE_SAMESITE=None
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,27 +2,10 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Django (Docker)",
-      "type": "debugpy",
-      "request": "attach",
-      "connect": {
-        "host": "localhost",
-        "port": 5678
-      },
-      "pathMappings": [
-        {
-          "localRoot": "${workspaceFolder}",
-          "remoteRoot": "/app"
-        }
-      ],
-      "django": true,
-      "preLaunchTask": "Start Debug Environment"
-    },
-    {
-      "name": "Start App (no debug)",
+      "name": "Start Dev Environment",
       "type": "node-terminal",
       "request": "launch",
-      "command": "echo 'Dev environment started — use the terminal panels to monitor docker compose and ngrok.'",
+      "command": "echo 'Dev environment started — docker compose and ngrok are running in the terminal panels below.'",
       "preLaunchTask": "Start Dev Environment"
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,18 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Start Dev Environment",
+      "name": "Local + Dev Login",
       "type": "node-terminal",
       "request": "launch",
-      "command": "echo 'Dev environment started — docker compose and ngrok are running in the terminal panels below.'",
-      "preLaunchTask": "Start Dev Environment"
+      "command": "echo 'App is running — visit a dev login link: http://localhost:8000/dev/login/instructor/'",
+      "preLaunchTask": "Docker Compose Up"
+    },
+    {
+      "name": "Local + Canvas",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "echo 'Docker compose and ngrok are running — install the tool in Canvas using the ngrok URL.'",
+      "preLaunchTask": "Local + Canvas"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Django (Docker)",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "/app"
+        }
+      ],
+      "django": true,
+      "preLaunchTask": "Start Debug Environment"
+    },
+    {
+      "name": "Start App (no debug)",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "echo 'Dev environment started — use the terminal panels to monitor docker compose and ngrok.'",
+      "preLaunchTask": "Start Dev Environment"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,89 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Docker Compose Up",
+      "type": "shell",
+      "command": "docker compose up",
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev"
+      }
+    },
+    {
+      "label": "Docker Compose Debug Up",
+      "type": "shell",
+      "command": "docker compose -f docker-compose.yml -f docker-compose.debug.yml up --build",
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev"
+      }
+    },
+    {
+      "label": "Ngrok",
+      "type": "shell",
+      "command": "ngrok http --scheme=https 8000",
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev"
+      }
+    },
+    {
+      "label": "Start Dev Environment",
+      "dependsOn": ["Docker Compose Up", "Ngrok"],
+      "dependsOrder": "parallel",
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "default"
+      }
+    },
+    {
+      "label": "Start Debug Environment",
+      "dependsOn": ["Docker Compose Debug Up", "Ngrok"],
+      "dependsOrder": "parallel",
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "default"
+      }
+    },
+    {
+      "label": "Run All Tests",
+      "type": "shell",
+      "command": "docker compose run --rm web python manage.py test policy_wizard --settings=academic_integrity_tool_v2.settings.test -v 2",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "Run Script Tag Validation Tests",
+      "type": "shell",
+      "command": "docker compose run --rm web python manage.py test policy_wizard.tests_script_tag_validation --settings=academic_integrity_tool_v2.settings.test -v 2",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "Docker Compose Down",
+      "type": "shell",
+      "command": "docker compose down",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
       }
     },
     {
-      "label": "Start Dev Environment",
+      "label": "Local + Canvas",
       "dependsOn": ["Docker Compose Up", "Ngrok"],
       "dependsOrder": "parallel",
       "problemMatcher": [],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,18 +14,6 @@
       }
     },
     {
-      "label": "Docker Compose Debug Up",
-      "type": "shell",
-      "command": "docker compose -f docker-compose.yml -f docker-compose.debug.yml up --build",
-      "isBackground": true,
-      "problemMatcher": [],
-      "presentation": {
-        "reveal": "always",
-        "panel": "dedicated",
-        "group": "dev"
-      }
-    },
-    {
       "label": "Ngrok",
       "type": "shell",
       "command": "ngrok http --scheme=https 8000",
@@ -47,15 +35,6 @@
       }
     },
     {
-      "label": "Start Debug Environment",
-      "dependsOn": ["Docker Compose Debug Up", "Ngrok"],
-      "dependsOrder": "parallel",
-      "problemMatcher": [],
-      "runOptions": {
-        "runOn": "default"
-      }
-    },
-    {
       "label": "Run All Tests",
       "type": "shell",
       "command": "docker compose run --rm web python manage.py test policy_wizard --settings=academic_integrity_tool_v2.settings.test -v 2",
@@ -66,9 +45,9 @@
       }
     },
     {
-      "label": "Run Script Tag Validation Tests",
+      "label": "Run Validation Tests",
       "type": "shell",
-      "command": "docker compose run --rm web python manage.py test policy_wizard.tests_script_tag_validation --settings=academic_integrity_tool_v2.settings.test -v 2",
+      "command": "docker compose run --rm web python manage.py test policy_wizard.tests_validations --settings=academic_integrity_tool_v2.settings.test -v 2",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+This file provides guidance for coding agents when working with code in this repository.
+
+## Project Overview
+
+Django LTI tool that enables instructors to prepare AI use policies from templates managed by instructional technologists and publish them for students to view. Embedded in and launched from the Canvas LMS via LTI.
+
+**Roles**: Administrator (manages templates) → Instructor (creates/publishes policies from templates) → Student (views published policy)
+
+**Data flow**: LTI launch → Role identification → Template selection → Policy creation/editing → Student viewing
+
+## Commands
+
+**All commands run inside Docker.** Do not install or run Python/Django directly on the host.
+
+```bash
+# Start the application
+docker compose up
+
+# Run all tests
+docker compose run --rm web python manage.py test policy_wizard --settings=academic_integrity_tool_v2.settings.test -v 2
+
+# Run a specific test class
+docker compose run --rm web python manage.py test policy_wizard.tests.RoleAndPermissionTests --settings=academic_integrity_tool_v2.settings.test -v 2
+
+# Run a single test
+docker compose run --rm web python manage.py test policy_wizard.tests.InstructorRoleTests.testPublishNewPolicy --settings=academic_integrity_tool_v2.settings.test -v 2
+
+# Run migrations
+docker compose run --rm web python manage.py migrate
+
+# Load fixture data
+docker compose run --rm web python manage.py loaddata boilerplate_policy_templates
+```
+
+## Architecture
+
+- **Python 3.6**, **Django 3.2** (runs in Docker)
+- **Models**: `PolicyTemplates` (boilerplate templates managed by admins) → `Policies` (course-specific, created by instructors, FK to template)
+- **Rich text**: TinyMCE (`django-tinymce`) for `body` fields; output rendered with `|safe` template filter
+- **LTI**: `django-lti-provider` for Canvas LMS integration; roles derived from `ext_roles` in LTI launch params
+- **Settings**: `base.py` → `local.py` (dev) / `aws.py` (production) / `test.py` (SQLite in-memory)
+- **Infrastructure**: Docker Compose with PostgreSQL (dev/prod), Redis (caching), SQLite (tests)
+
+## Key Patterns
+
+- **Role-based access**: Views use `@require_role_instructor`, `@require_role_student`, `@require_role_admin` decorators from `decorators.py`
+- **Form validation**: `ModelForm` classes (`NewPolicyForm`, `PolicyTemplateForm`) inherit field validators from model fields automatically
+- **Field validators**: `validators=[validate_no_script_tags]` on model `body` fields — runs during `form.is_valid()` and `model.full_clean()` but NOT on direct ORM `save()`/`create()` (by design — developer escape hatch)
+- **Fixtures**: `policy_wizard/fixtures/boilerplate_policy_templates.yml` contains all 7 policy templates (PKs 1-7)
+- **Template rendering**: All `body` fields use `|safe` in Django templates — server-side validation is the trust boundary
+
+## Testing
+
+Use Django's `unittest`-based `TestCase` with `RequestFactory` for view tests.
+
+```bash
+# Run all policy_wizard tests
+docker compose run --rm web python manage.py test policy_wizard --settings=academic_integrity_tool_v2.settings.test -v 2
+
+# Run only validation tests
+docker compose run --rm web python manage.py test policy_wizard.tests_validations --settings=academic_integrity_tool_v2.settings.test -v 2
+```
+
+### Standards
+
+- **Assertions**: Use `assertEqual` (not `assertEquals`). Use `assertTrue`/`assertFalse` for truthy/falsy checks on `SmallIntegerField` boolean flags. Never pass an expected value as the second argument to `assertTrue` — it's the failure message, not a comparison.
+- **Fixtures**: Use `fixtures = ['boilerplate_policy_templates']` on test classes that need templates — do not manually create templates in `setUp`.
+- **Fixture PKs**: Reference templates by named constants (`MAXIMALLY_RESTRICTIVE_PK`, `MIXED_POLICY_PK`, etc.) defined at the top of `tests.py`, not bare integers.
+- **RawPostDataException**: Views with diagnostic logging that access `request.body` after `request.POST` require `mock.patch.object(type(request), 'body', ...)` in tests. The diagnostic logging is marked for removal.
+- **Coverage**: Test both the positive case (safe HTML accepted, 302 redirect) and the negative case (script tags rejected, 200 re-render with form errors).
+
+## File Organization
+
+```
+policy_wizard/
+├── models.py                    # PolicyTemplates, Policies (body fields with validators)
+├── validators.py                # validate_no_script_tags (regex-based script tag detection)
+├── forms.py                     # NewPolicyForm, PolicyTemplateForm (plain ModelForms)
+├── views.py                     # Role-gated views for all CRUD operations
+├── decorators.py                # @require_role_* permission decorators
+├── roles.py                     # Role constants (ADMINISTRATOR, INSTRUCTOR, STUDENT)
+├── utils.py                     # Helper functions (inactivate_active_policies, etc.)
+├── urls.py                      # URL routing
+├── tests.py                     # LTI launch, role permission, and CRUD tests
+├── tests_validations.py             # Script tag validation tests (32 tests)
+├── fixtures/
+│   └── boilerplate_policy_templates.yml  # 7 policy templates (PKs 1-7)
+└── migrations/
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ open http://localhost:8000
 $ docker compose run web python manage.py test
 ```
 
+### Local Dev Login (no Canvas / LTI required)
+
+When `DEBUG=True`, you can bypass the LTI launch and view the app as any role by visiting one of the URLs below. This seeds the Django session with the chosen role and fake course identifiers, then redirects to that role's landing page.
+
+| Role | URL |
+|------|-----|
+| Instructor | http://localhost:8000/dev/login/instructor/ |
+| Student | http://localhost:8000/dev/login/student/ |
+| Admin | http://localhost:8000/dev/login/admin/ |
+
+Your session persists until you clear cookies or visit a different role link to switch.
+
+> **These routes are only registered when `DEBUG=True` and will 404 in production.**
+
+This is a convenience for quickly testing UI changes, template rendering, and form behavior without needing to set up Canvas, ngrok, or a full LTI handshake. It is **not** a replacement for integrated LTI testing — you should still verify the full LTI launch flow (Canvas → ngrok → LTI handshake → role identification → session) before considering work complete.
+
 #### Integrated Testing
 
 When this tool is launched from Canvas, it is embedded in an `iframe` from a secure (`https-` based) site. For the cross-domain session and CSRF cookies to function correctly, our Django settings are configured with `SESSION_COOKIE_SECURE = True` and `CSRF_COOKIE_SECURE = True`. These settings command the browser to only send cookies over a secure HTTPS connection.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,41 @@ This is a [django](https://www.djangoproject.com/) application that enables inst
 
 ## Installing the tool in the Canvas LMS
 
-Follow the Canvas Admin Guide on [How do I configure an external app for an account using XML?](https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-external-app-for-an-account-using-XML/ta-p/221). This can be done at either the sub-account level or in a specific canvas course by visiting that course's settings.
+The tool is installed in Canvas as an LTI External App. There are two installation methods:
 
-The key details you will need include:
+### Method 1: By URL (recommended)
 
-- **Consumer key**: obtain this from `academic_integrity_tool_v2/settings/.env.example`
-- **Shared secret**: obtain this from `academic_integrity_tool_v2/settings/.env.example`
-- **XML configuration**: obtain this from http://localhost:8000/lti/config. Or with ngrok, [https://<random-string>.ngrok-free.app/lti/config](https://ngrok.com/docs/universal-gateway/domains/#ngrok-managed-domains)
+Canvas fetches the tool's XML configuration from a URL you provide.
 
-Once installed, the tool should be displayed in the left-hand course navigation as **AI Policy**. Note that it may be disabled in the navigation by default, so you may need to manually enable it in the course settings navigation (drag and drop to move to the desired position).
+| Environment | Config URL |
+|-------------|-----------|
+| **Production** | `https://academicintegritytoolv2.tlt.harvard.edu/lti/config` |
+| **Local dev** (via ngrok) | `https://<ngrok-subdomain>.ngrok-free.app/lti/config` |
+
+In the Canvas "Add App" dialog, select **Configuration Type: By URL** and enter:
+
+| Field | Value |
+|-------|-------|
+| **Name** | AI Policy |
+| **Consumer Key** | `CONSUMER_KEY` from `.env` |
+| **Shared Secret** | `LTI_SECRET` from `.env` |
+| **Config URL** | The URL from the table above |
+
+### Method 2: Paste XML
+
+If "By URL" isn't available or you prefer manual configuration, you can paste the XML directly.
+
+1. Open the config URL in a browser (e.g. `https://<ngrok-subdomain>.ngrok-free.app/lti/config`)
+2. Copy the full XML response
+3. In the Canvas "Add App" dialog, select **Configuration Type: Paste XML**
+4. Enter the **Name**, **Consumer Key**, and **Shared Secret** (same values as above)
+5. Paste the XML into the **XML Configuration** field
+
+### After installation
+
+The tool should appear in the left-hand course navigation as **AI Policy**. If it doesn't, go to **Course Settings → Navigation**, drag **AI Policy** up from the hidden section, and click **Save**.
+
+> For the full step-by-step installation walkthrough with screenshots, see [AI Policy tool (ECS) - LTI Installation Instructions](https://docs.google.com/document/d/1w7QTOgFuvTAObeQUSVTK3HATDbeHLKNYLI72eytu8FM/edit?usp=drive_link) (AT Shared Drive: `FAS Service Team > Platform and Tools > Academic Integrity Policy Wizard > documentation`).
 
 ## Developer Notes
 
@@ -22,24 +48,30 @@ The instructions below assume you have [Docker](https://www.docker.com/) install
 
 ### Getting setup
 
-Configure django settings:
+Configure environment variables and start the app:
 
-```
-$ cp academic_integrity_tool_v2/.env.example academic_integrity_tool_v2/settings/.env
+```bash
+# Copy the example env file — all defaults work out of the box
+$ cp .env.example .env
 
-```
-
-Run the application:
-
-```
+# Start the app (Django + Postgres + Redis)
 $ docker compose up
-
 ```
 
-Open the tool in your web browser to verify it is up and running:
+In a separate terminal, run migrations and load the policy templates:
 
+```bash
+# Create database tables
+$ docker compose run --rm web python manage.py migrate
+
+# Load the 7 boilerplate policy templates
+$ docker compose run --rm web python manage.py loaddata boilerplate_policy_templates
 ```
-open http://localhost:8000
+
+Verify it's running — visit a dev login link to enter the app:
+
+```bash
+$ open http://localhost:8000/dev/login/instructor/  # macOS; use xdg-open on Linux
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Your session persists until you clear cookies or visit a different role link to 
 
 This is a convenience for quickly testing UI changes, template rendering, and form behavior without needing to set up Canvas, ngrok, or a full LTI handshake. It is **not** a replacement for integrated LTI testing — you should still verify the full LTI launch flow (Canvas → ngrok → LTI handshake → role identification → session) before considering work complete.
 
+### VS Code Tasks
+
+Pre-configured tasks are available via **Terminal → Run Task** or the **Run and Debug** panel:
+
+| Task | What it does |
+|------|-------------|
+| **Start Dev Environment** | Runs `docker compose up` + `ngrok` in parallel — one click to get both running for LTI testing |
+| Docker Compose Up | `docker compose up` (just the app, no ngrok) |
+| Ngrok | `ngrok http --scheme=https 8000` |
+| Run All Tests | Runs the full test suite in Docker |
+| Run Validation Tests | Runs only `tests_validations.py` |
+| Docker Compose Down | `docker compose down` |
+
+From the **Run and Debug** panel (▶️), select **"Start Dev Environment"** to launch Docker Compose and ngrok together. The dev login URLs will be printed in the Docker terminal output.
+
 #### Integrated Testing
 
 When this tool is launched from Canvas, it is embedded in an `iframe` from a secure (`https-` based) site. For the cross-domain session and CSRF cookies to function correctly, our Django settings are configured with `SESSION_COOKIE_SECURE = True` and `CSRF_COOKIE_SECURE = True`. These settings command the browser to only send cookies over a secure HTTPS connection.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,16 @@ open http://localhost:8000
 $ docker compose run web python manage.py test
 ```
 
-### Local Dev Login (no Canvas / LTI required)
+### Development Workflows
 
-When `DEBUG=True`, you can bypass the LTI launch and view the app as any role by visiting one of the URLs below. This seeds the Django session with the chosen role and fake course identifiers, then redirects to that role's landing page.
+There are two workflows for local development, depending on whether you need Canvas integration.
+
+#### Local + Dev Login (no Canvas / LTI integration)
+
+For UI changes, template rendering, form behavior — anything that doesn't need a real LTI launch.
+
+1. `docker compose up` (or Run and Debug → **"Local + Dev Login"**)
+2. Visit a dev login link to seed your session with a role:
 
 | Role | URL |
 |------|-----|
@@ -58,53 +65,39 @@ When `DEBUG=True`, you can bypass the LTI launch and view the app as any role by
 | Student | http://localhost:8000/dev/login/student/ |
 | Admin | http://localhost:8000/dev/login/admin/ |
 
-Your session persists until you clear cookies or visit a different role link to switch.
+You'll be redirected to that role's landing page. Switch roles by clicking a different link. Session persists until you clear cookies.
 
 > **These routes are only registered when `DEBUG=True` and will 404 in production.**
 
-This is a convenience for quickly testing UI changes, template rendering, and form behavior without needing to set up Canvas, ngrok, or a full LTI handshake. It is **not** a replacement for integrated LTI testing — you should still verify the full LTI launch flow (Canvas → ngrok → LTI handshake → role identification → session) before considering work complete.
+#### Local + Canvas (integrated LTI testing)
+
+For testing the full LTI flow: Canvas launch → ngrok → LTI handshake → role identification → session. Use this to verify cross-domain cookies, secure context behavior, and the actual install/launch experience.
+
+1. Start both services — either manually or from VS Code:
+   - **Manual:** `docker compose up` in one terminal, `ngrok http --scheme=https 8000` in another
+   - **VS Code:** Run and Debug panel → **"Local + Canvas"** (launches both in parallel)
+2. Copy the ngrok HTTPS URL (e.g. `https://<random-string>.ngrok-free.app`)
+3. In Canvas course settings, install the LTI tool using the XML config URL: `https://<random-string>.ngrok-free.app/lti/config`
+4. Launch the tool from Canvas course navigation — it should appear as **AI Policy**
+
+**Why ngrok is required:** Canvas embeds the tool in an iframe from a secure (`https`) site. Django's `SESSION_COOKIE_SECURE = True` and `CSRF_COOKIE_SECURE = True` settings require HTTPS for cookies to work. While `localhost` may appear to work (browsers treat it as a secure context), it doesn't simulate the real cross-domain iframe behavior. ngrok's `--scheme=https` flag ensures Django sees a secure connection.
 
 ### VS Code Tasks
 
 Pre-configured tasks are available via **Terminal → Run Task** or the **Run and Debug** panel:
 
-| Task | What it does |
-|------|-------------|
-| **Start Dev Environment** | Runs `docker compose up` + `ngrok` in parallel — one click to get both running for LTI testing |
-| Docker Compose Up | `docker compose up` (just the app, no ngrok) |
-| Ngrok | `ngrok http --scheme=https 8000` |
-| Run All Tests | Runs the full test suite in Docker |
-| Run Validation Tests | Runs only `tests_validations.py` |
-| Docker Compose Down | `docker compose down` |
+| Task | What it does | Workflow |
+|------|-------------|----------|
+| **Local + Canvas** | `docker compose up` + `ngrok` in parallel | Local + Canvas |
+| Docker Compose Up | `docker compose up` (app only) | Local + Dev Login |
+| Ngrok | `ngrok http --scheme=https 8000` | Local + Canvas |
+| Run All Tests | Full test suite in Docker | — |
+| Run Validation Tests | Only `tests_validations.py` | — |
+| Docker Compose Down | `docker compose down` | — |
 
-From the **Run and Debug** panel (▶️), select **"Start Dev Environment"** to launch Docker Compose and ngrok together. The dev login URLs will be printed in the Docker terminal output.
-
-#### Integrated Testing
-
-When this tool is launched from Canvas, it is embedded in an `iframe` from a secure (`https-` based) site. For the cross-domain session and CSRF cookies to function correctly, our Django settings are configured with `SESSION_COOKIE_SECURE = True` and `CSRF_COOKIE_SECURE = True`. These settings command the browser to only send cookies over a secure HTTPS connection.
-
-While local development on `http://localhost:8000` may appear to work for basic views, this is because modern browsers often treat `localhost` as a "secure context" and relax this policy. However, this does not accurately simulate the production LTI environment and will fail when trying to establish a valid cross-domain session.
-
-To properly test the LTI flow locally, you must expose your local development server on a public **HTTPS** URL. **NGROK** is a tool that provides this functionality.
-
-##### NGrok Configuration Steps
-
-1.  **Install NGROK**: Follow the [official instructions](https://ngrok.com/docs/getting-started/)
-
-2.  **Start the Django Server**: Run the local development server as usual.
-    ```bash
-    docker-compose up
-    ```
-
-3.  **Start NGROK**: In a separate terminal, run the following command to expose your local port 8000 on a public HTTPS URL.
-    ```bash
-    ngrok http --scheme=https 8000
-    ```
-    -   This command tells `ngrok` to forward traffic to your local `http://localhost:8000` but to set the forwarding scheme in the HTTP headers to `https`. This ensures Django recognizes the connection as secure, which is necessary for the secure cookie flags.
-
-4.  **Update Environment Variables**: NGROK will provide a public URL (ex., `https://<random-string>.ngrok-free.app`).
-
-5.  **Update Canvas**: In your Canvas course settings, add the LTI tool (see ***Original demos*** section below) using your new public NGROK URL XML page (ex., `https://<random-string>.ngrok-free.app/lti/config`). You can now launch the tool from Canvas to fully test the LTI flow against your local development server with behavior similar to production.
+From the **Run and Debug** panel (▶️):
+- **"Local + Dev Login"** — starts Docker Compose, then visit a dev login link
+- **"Local + Canvas"** — starts Docker Compose + ngrok, then install the tool in Canvas
 
 
 ### Update the Coverage Badge

--- a/academic_integrity_tool_v2/requirements/base.txt
+++ b/academic_integrity_tool_v2/requirements/base.txt
@@ -8,6 +8,6 @@ hiredis==1.1.0
 # Django LTI Provider
 django-lti-provider==0.3.1
 # Django-tinymce
-django-tinymce
+django-tinymce==3.6.1
 pyyaml==5.3.1
 requests==2.25.1

--- a/academic_integrity_tool_v2/requirements/local.txt
+++ b/academic_integrity_tool_v2/requirements/local.txt
@@ -5,6 +5,7 @@
 
 # below are requirements specific to the local environment
 django-debug-toolbar==3.1.1
+debugpy==1.5.1
 mock==4.0.2
 pep8==1.7.1
 flake8==3.9.2

--- a/academic_integrity_tool_v2/requirements/local.txt
+++ b/academic_integrity_tool_v2/requirements/local.txt
@@ -5,7 +5,6 @@
 
 # below are requirements specific to the local environment
 django-debug-toolbar==3.1.1
-debugpy==1.5.1
 mock==4.0.2
 pep8==1.7.1
 flake8==3.9.2

--- a/academic_integrity_tool_v2/settings/base.py
+++ b/academic_integrity_tool_v2/settings/base.py
@@ -120,9 +120,9 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 # be sent on the cross-site GET redirect after the initial POST launch.
 SESSION_COOKIE_SAMESITE = SECURE_SETTINGS.get('session_cookie_samesite', 'None')
 
-# The Secure flag must be True for cookies with SameSite=None. In production
-# environments with HTTPS, this must always be True. For local development
-# without HTTP, it must be set to False.
+# The Secure flag must be True for cookies with SameSite=None. This works across
+# all environments: production has real HTTPS, ngrok provides HTTPS for local Canvas
+# testing, and browsers treat localhost as a secure context even over plain HTTP.
 # We retrieve the value from an environment variable and default to True.
 SESSION_COOKIE_SECURE = SECURE_SETTINGS.get('session_cookie_secure', 'True') == 'True'
 

--- a/academic_integrity_tool_v2/settings/secure.py
+++ b/academic_integrity_tool_v2/settings/secure.py
@@ -36,8 +36,13 @@ SECURE_SETTINGS = {
     'X_FRAME_OPTIONS': os.environ['X_FRAME_OPTIONS'], # Security header to prevent clickjacking
 
     # Session / cookie management
-    'session_cookie_secure': os.environ.get('DJANGO_SESSION_COOKIE_SECURE', 'True'), # Use secure cookies
-    'session_cookie_samesite': os.environ.get('DJANGO_SESSION_COOKIE_SAMESITE', 'None'), # SameSite attribute for cookies
+    # Defaults work for both local dev and production:
+    # - localhost is treated as a secure context by browsers (Secure=True works over HTTP)
+    # - ngrok provides actual HTTPS
+    # - production is HTTPS
+    # See base.py for full explanation of SameSite/Secure cookie requirements.
+    'session_cookie_secure': os.environ.get('DJANGO_SESSION_COOKIE_SECURE', 'True'),
+    'session_cookie_samesite': os.environ.get('DJANGO_SESSION_COOKIE_SAMESITE', 'None'),
 
     # Misc
     'help_email_address': os.environ.get('HELP_EMAIL_ADDRESS', 'help@example.com'),

--- a/academic_integrity_tool_v2/urls.py
+++ b/academic_integrity_tool_v2/urls.py
@@ -27,6 +27,12 @@ urlpatterns = [
     path('tinymce/', include('tinymce.urls')),
 ]
 
+if settings.DEBUG:
+    from policy_wizard.dev_views import dev_login_view
+    urlpatterns += [
+        path('dev/login/<str:role_slug>/', dev_login_view, name='dev_login'),
+    ]
+
 
 if settings.DEBUG_TOOLBAR:
     import debug_toolbar

--- a/academic_integrity_tool_v2/urls.py
+++ b/academic_integrity_tool_v2/urls.py
@@ -15,15 +15,24 @@ Including another URLconf
 from django.conf import settings
 from django.urls import include, path
 from django.contrib import admin
+from django.views.decorators.csrf import csrf_exempt
 from lti_provider import views as lti_views
 from .health_check_view import health_check_view
+
+
+# Canvas GETs /lti/config during "By URL" tool installation, but other LMS
+# implementations may POST.  Adding csrf_exempt + POST support ensures the
+# XML config endpoint works regardless of HTTP method.
+class LTIConfigViewWithPost(lti_views.LTIConfigView):
+    """Extend LTIConfigView to accept POST (some LMS send POST during 'By URL' install)."""
+    post = lti_views.LTIConfigView.get
 
 
 urlpatterns = [
     path('health', health_check_view, name='health_check'),
     path('admin/', admin.site.urls),
     path('lti/launch/', include('policy_wizard.urls')),
-    path('lti/config', lti_views.LTIConfigView.as_view(), name="get_lti_xml"),
+    path('lti/config', csrf_exempt(LTIConfigViewWithPost.as_view()), name="get_lti_xml"),
     path('tinymce/', include('tinymce.urls')),
 ]
 

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,25 @@
+# Override for VS Code debugging — starts Django under debugpy so the
+# VS Code debugger can attach.  Used automatically by the "Debug Django
+# (Docker)" launch configuration.
+#
+# The ENTRYPOINT (entrypoint.sh) already waits for the DB, runs
+# migrations, and loads fixtures.  This override only replaces the CMD
+# so Django runs under debugpy.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.debug.yml up --build
+services:
+  web:
+    command:
+      - "python3"
+      - "-m"
+      - "debugpy"
+      - "--listen"
+      - "0.0.0.0:5678"
+      - "manage.py"
+      - "runserver"
+      - "0.0.0.0:8000"
+      - "--noreload"
+    ports:
+      - "8000:8000"
+      - "5678:5678"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,17 @@ services:
       POSTGRES_USER: "${DB_USER}"
       POSTGRES_DB: "${DB_NAME}"
   # Note: run "docker-compose run web python3 manage.py migrate" after the web service is up
+  #
+  # Dev login (no Canvas/LTI required, DEBUG=True only):
+  #   Instructor: http://localhost:8000/dev/login/instructor/
+  #   Student:    http://localhost:8000/dev/login/student/
+  #   Admin:      http://localhost:8000/dev/login/admin/
   web:
     build: .
     image: academic_integrity_tool_v2
     env_file:
       - .env
-    command: ["./docker-wait-for-it.sh", "db:5432", "--", "python3", "manage.py", "runserver", "0.0.0.0:8000"]
+    command: ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
     environment:
       DJANGO_SETTINGS_MODULE: "academic_integrity_tool_v2.settings.local"
       NGROK_DOMAIN: "${NGROK_DOMAIN}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,10 +9,6 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-# --- DEBUGGING LINE ---
-echo "DJANGO_SETTINGS_MODULE is set to: $DJANGO_SETTINGS_MODULE"
-# --- END DEBUGGING LINE ---
-
 # Local only: Wait for the database service to be available. Not needed in dev/prod using long running services.
 if [[ "$DJANGO_SETTINGS_MODULE" == *"local"* ]]; then
     echo "Waiting for database to be ready..."
@@ -32,4 +28,16 @@ fi
 # Execute the main command from the Dockerfile's CMD.
 # This passes control to the real application and executes the startup command.
 echo "Starting Django Server application..."
+
+# Local only: print dev login URLs for quick access without Canvas/LTI.
+if [[ "$DJANGO_SETTINGS_MODULE" == *"local"* ]]; then
+    echo ""
+    echo "App is up — migrations applied, fixtures loaded. Try these in your browser:"
+    echo ""
+    echo "  Instructor: http://localhost:8000/dev/login/instructor/"
+    echo "  Student:    http://localhost:8000/dev/login/student/"
+    echo "  Admin:      http://localhost:8000/dev/login/admin/"
+    echo ""
+fi
+
 exec "$@" # Replaces the shell with the Django server process

--- a/policy_wizard/dev_views.py
+++ b/policy_wizard/dev_views.py
@@ -1,0 +1,49 @@
+"""
+Dev-only view that simulates an LTI launch by seeding the session with
+a chosen role.  Gated by settings.DEBUG so it can never run in production.
+
+Usage:
+    http://localhost:8000/dev/login/instructor/
+    http://localhost:8000/dev/login/student/
+    http://localhost:8000/dev/login/admin/
+"""
+from django.conf import settings
+from django.http import Http404, HttpResponse
+from django.shortcuts import redirect
+
+from policy_wizard import roles
+
+# Map URL slugs to the role constants the app expects.
+ROLE_MAP = {
+    'instructor': roles.INSTRUCTOR,
+    'student': roles.STUDENT,
+    'admin': roles.ADMINISTRATOR,
+}
+
+# Fake values that satisfy the session keys views depend on.
+DEV_COURSE_ID = 99999
+DEV_CONTEXT_ID = 'dev-context-1'
+DEV_PERSON_ID = 'dev-user'
+
+
+def dev_login_view(request, role_slug):
+    """Seed the session and redirect to the appropriate landing page."""
+    if not settings.DEBUG:
+        raise Http404
+
+    role = ROLE_MAP.get(role_slug)
+    if role is None:
+        return HttpResponse(
+            f"Unknown role '{role_slug}'. Use one of: {', '.join(ROLE_MAP.keys())}",
+            status=400,
+        )
+
+    request.session['role'] = role
+    request.session['course_id'] = DEV_COURSE_ID
+    request.session['context_id'] = DEV_CONTEXT_ID
+    request.session['lis_person_sourcedid'] = DEV_PERSON_ID
+
+    if role == roles.STUDENT:
+        return redirect('student_active_policy')
+    else:
+        return redirect('policy_templates_list')


### PR DESCRIPTION
# Overview

This PR sets up two clear development workflows, builds on #39. 

**Local + Dev Login** — Run and Debug → "Local + Dev Login" → Docker Compose starts → click a dev login link → you're in the app as instructor, student, or admin. No Canvas, no ngrok, no LTI handshake. For UI changes, you template rendering, form behavior — anything that doesn't need a real LTI launch.

**Local + Canvas** — Run and Debug → "Local + Canvas" → Docker Compose and ngrok spin up together. Install the tool in Canvas using the ngrok URL, launch from course navigation, and test the full LTI flow with cross-domain cookies and secure context — matching production behavior.

This PR also adds startup cleanup and AI agent documentation.

# Changes

### Dev Login
- Added `policy_wizard/dev_views.py` — `dev_login_view` seeds the session with role, course ID, and context ID, then redirects to the role's landing page
- Added conditional URL registration in `urls.py` — `/dev/login/<role>/` only when `DEBUG=True`
- Added dev login section to `README.md` with role URLs and usage notes

### VS Code Tooling
- Added `.vscode/tasks.json` — 6 tasks (dev up, ngrok, compound start, tests, teardown)
- Added `.vscode/launch.json` — two Run & Debug entries: "Local + Dev Login" (app only) and "Local + Canvas" (app + ngrok)

### Startup Cleanup
- Simplified `docker-compose.yml` command — removed `docker-wait-for-it.sh` wrapper (already handled by `entrypoint.sh`)
- Added dev login URL banner to `entrypoint.sh` (local settings only)

### AI Agent Docs
- Added `AGENTS.md` — project overview, Docker commands, architecture, key patterns, testing standards, file organization
- Added `CLAUDE.md` — points to `AGENTS.md` via `@AGENTS.md` reference

# Notes

## Dev Login

<details>
<summary>Session keys seeded</summary>

| Key | Value |
|-----|-------|
| `role` | `'Instructor'`, `'Student'`, or `'Administrator'` (matches `roles.py` constants) |
| `course_id` | `99999` (integer — matches `IntegerField` on `Policies` model) |
| `context_id` | `'dev-context-1'` |
| `lis_person_sourcedid` | `'dev-user'` |

Switching roles: visit a different role URL. The session is shared, so the new role overwrites the previous one.
</details>

<details>
<summary>Production safety</summary>

Two independent guards:
1. The URL route is only registered when `settings.DEBUG is True`
2. The view itself checks `settings.DEBUG` and raises `Http404` if false

Both must fail for the route to be accessible in production.
</details>

## VS Code Tooling

From the **Run and Debug** panel, select **"Local + Dev Login"** (app only) or **"Local + Canvas"** (app + ngrok) to start the appropriate workflow.

<details>
<summary>Available tasks (Terminal → Run Task)</summary>

| Task | What it does |
|------|-------------|
| **Local + Canvas** | Compound: Docker Compose Up + Ngrok in parallel |
| Docker Compose Up | `docker compose up` (just the app) |
| Ngrok | `ngrok http --scheme=https 8000` |
| Run All Tests | Full test suite in Docker |
| Run Validation Tests | Only `tests_validations.py` |
| Docker Compose Down | `docker compose down` |
</details>

## Startup Cleanup

<details>
<summary>Docker Compose command change</summary>

Before:
```yaml
command: ["./docker-wait-for-it.sh", "db:5432", "--", "python3", "manage.py", "runserver", "0.0.0.0:8000"]
```

After:
```yaml
command: ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
```

The `entrypoint.sh` already waits for the database, so the `docker-wait-for-it.sh` wrapper was redundant.
</details>

# Testing

Manual testing steps:

1. `docker compose up`
2. Visit http://localhost:8000/dev/login/instructor/ — redirects to template list
3. Visit http://localhost:8000/dev/login/student/ — redirects to student policy view
4. Visit http://localhost:8000/dev/login/admin/ — redirects to admin template list
5. Visit http://localhost:8000/dev/login/bogus/ — returns 400

VS Code Run & Debug:
1. Open Run and Debug panel → select "Local + Dev Login" or "Local + Canvas" → press ▶️
2. "Local + Dev Login" starts Docker Compose; "Local + Canvas" starts Docker Compose + ngrok in parallel
3. Dev login URLs print in the Docker output
