### PR TITLE
Use CDN for Quill Editor Static Files

### DIFF
--- a/templates/quill_editor_base.html
+++ b/templates/quill_editor_base.html
@@ -24,6 +24,12 @@
     6. Server-side: the validator checks for XSS, then saves the Delta JSON to the DB
     7. At display time: the |render_body filter converts Delta JSON back to safe HTML
 
+    WHY CDN INSTEAD OF VENDORED STATIC FILES:
+    This deployment has no static file serving layer (no whitenoise, nginx, or S3).
+    Django only serves app static files when DEBUG=True, so vendored files in
+    policy_wizard/static/quill/ return 404 in production. Quill is loaded from
+    jsDelivr (pinned to @2.0.3) — same pattern as Bootstrap and Font Awesome.
+
     CHILD TEMPLATES must:
     - Extend this template
     - Override {% block editorContent %} with their form
@@ -31,9 +37,6 @@
 {% endcomment %}
 
 {% block extra_head %}
-    {# Quill 2.0.3 "Snow" theme — loaded from CDN because this deployment has no
-       static file serving layer (no whitenoise/nginx/S3). Django only serves app
-       static files when DEBUG=True, so vendored files 404 in prod. #}
     <link href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" rel="stylesheet">
     <style>
         /* Size the editor to match the old TinyMCE editor height */

--- a/templates/quill_editor_base.html
+++ b/templates/quill_editor_base.html
@@ -30,11 +30,11 @@
     - Include <div id="quill-editor"></div> inside the form, after {{ form.body }}
 {% endcomment %}
 
-{% load static %}
-
 {% block extra_head %}
-    {# Quill 2.0.3 "Snow" theme — vendored in policy_wizard/static/quill/ #}
-    <link href="{% static 'quill/quill.snow.css' %}" rel="stylesheet">
+    {# Quill 2.0.3 "Snow" theme — loaded from CDN because this deployment has no
+       static file serving layer (no whitenoise/nginx/S3). Django only serves app
+       static files when DEBUG=True, so vendored files 404 in prod. #}
+    <link href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" rel="stylesheet">
     <style>
         /* Size the editor to match the old TinyMCE editor height */
         #quill-editor {
@@ -59,7 +59,7 @@
 
 {% block extra_script %}
     {# Load Quill after the DOM is rendered (in extra_script, which is at end of <body>) #}
-    <script src="{% static 'quill/quill.js' %}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.js"></script>
     <script>
         (function() {
             // The hidden textarea that Django's form machinery reads on submit


### PR DESCRIPTION
# Overview

The Quill editor was not rendering in production — 404 errors on `/static/quill/quill.js` and `/static/quill/quill.snow.css`. The edit page loaded with no toolbar and no content area.

Deployed  this as a fall-forward fix. This fix switches Quill from vendored static files to a pinned CDN version (jsDelivr). The editor now loads in both dev and production. Backlog item for whitenoise (static file serving layer) outlined below.

# Changes

- `templates/quill_editor_base.html` — replaced `{% static %}` references with pinned jsDelivr CDN URLs, removed `{% load static %}`

```html
<!-- Before (404 in prod): -->
<link href="{% static 'quill/quill.snow.css' %}" rel="stylesheet">
<script src="{% static 'quill/quill.js' %}"></script>

<!-- After (works everywhere): -->
<link href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" rel="stylesheet">
<script src="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.js"></script>
```

# Notes

## What Happened

Quill's JS and CSS were bundled as static files in `policy_wizard/static/quill/`. This worked locally (`DEBUG=True` — Django serves static files automatically) but 404'd in production (`DEBUG=False` — Django does not serve static files without a serving layer).

<details>
<summary>Why the previous TinyMCE setup worked</summary>

TinyMCE was a pip package (`django-tinymce`) registered in `INSTALLED_APPS`. Django's `staticfiles` finders could locate its assets. It's unclear how they were actually served in production — there's no `collectstatic` in the project history, no whitenoise, no nginx. The infrastructure may have handled it differently before the ECS migration, or `DEBUG` may have been configured differently. Either way, there's no static file serving layer in the current deployment.
</details>

## Why CDN

We didn't initially go with CDN because the editor is the core functionality — if it doesn't load, there's nothing to use. We wanted controlled, predictable delivery. However, the app already uses CDNs for Bootstrap (structural — layout, grid, modals) and Font Awesome (icons), both stable for the life of the app. Bootstrap is critical — without it the page breaks entirely — so CDN delivery works for core dependencies when the library is stable and version-pinned.

CDN - Stable and Viable Option

jsDelivr serves 150+ billion requests/month, backed by multiple providers (Cloudflare, Fastly, Stackpath) with built-in failover.

The version is **pinned to `@2.0.3`** — an exact version, not a range. This URL is immutable: once published, jsDelivr always serves this specific build. Rolling updates or new Quill releases won't affect our app unless we explicitly change the version number.

Quill itself is mature and well-maintained (43k+ GitHub stars, active development by Slab).

## What It Would Take to Use Static Files Instead

<details>
<summary>Why static files don't work today</summary>

Django's `staticfiles` app can **find** static files but does not **serve** them when `DEBUG=False`. It expects a separate layer (nginx, S3, or whitenoise) to handle `/static/...` requests. Our deployment has no such layer — the Django process receives all requests directly via the ALB.
</details>

<details>
<summary>Options</summary>

| Approach | What it does | Complexity |
|---|---|---|
| **Whitenoise** | Middleware that serves static files from the Python process | Low — pip install + 3 config lines |
| **Nginx sidecar** | Separate ECS container serves `/static/` from shared volume | Medium — new container, task def changes |
| **S3 + CloudFront** | `collectstatic` uploads to S3, `STATIC_URL` points to CloudFront | Medium — AWS resources, django-storages, IAM |
</details>

<details>
<summary>Whitenoise implementation (3 additions)</summary>

[Whitenoise](http://whitenoise.evans.io/) adds static file serving into the Django middleware stack. Standard solution for Django on platforms without a built-in serving layer (Heroku, ECS). Recommended in the [Django deployment docs](https://docs.djangoproject.com/en/3.2/howto/static-files/deployment/).

1. **Add to requirements:**
   ```
   whitenoise==6.5.0
   ```

2. **Add middleware** (after `SecurityMiddleware`):
   ```python
   'whitenoise.middleware.WhiteNoiseMiddleware',
   ```

3. **Run `collectstatic` in entrypoint** (before `exec "$@"`):
   ```bash
   python manage.py collectstatic --no-input
   ```

References: [Whitenoise docs](http://whitenoise.evans.io/) · [Django static files deployment](https://docs.djangoproject.com/en/3.2/howto/static-files/deployment/) · [collectstatic](https://docs.djangoproject.com/en/3.2/ref/contrib/staticfiles/#collectstatic)
</details>

## Backlog

Adding whitenoise + `collectstatic` is a reasonable future enhancement — lets us vendor any static asset without CDN dependency. Not blocking. The CDN approach is stable, pinned, and matches the existing pattern in this app. Low-priority infrastructure task.

Deployed to production as a fall-forward fix because the editor page was non-functional. If we add whitenoise later, we could switch back to vendored files — no urgency given CDN stability.

# Testing

- Tested locally — editor loads and functions correctly with CDN URLs
- Pinned version (`@2.0.3`) matches the version previously vendored in `policy_wizard/static/quill/`
- Vendored files in `policy_wizard/static/quill/` can be removed in a follow-up cleanup once CDN is confirmed stable in production

# References

- [jsDelivr](https://www.jsdelivr.com/) — CDN used for Quill, Bootstrap, and Font Awesome in this app
- [Quill 2.0.3 on jsDelivr](https://www.jsdelivr.com/package/npm/quill?version=2.0.3) — pinned version
- [Whitenoise docs](http://whitenoise.evans.io/) — static file serving middleware (backlog)
- [Django static files deployment](https://docs.djangoproject.com/en/3.2/howto/static-files/deployment/)
- [Django collectstatic](https://docs.djangoproject.com/en/3.2/ref/contrib/staticfiles/#collectstatic)
